### PR TITLE
Fix: show meaningful state when card has no items or connection fails

### DIFF
--- a/dist/recently-added-media-card.js
+++ b/dist/recently-added-media-card.js
@@ -572,6 +572,9 @@ class RecentlyAddedMediaCard extends HTMLElement {
         errEl.textContent = `Could not connect to ${serverType}: ${err.message}`;
         errEl.style.display = 'block';
       }
+      this._items = [];
+      this._currentIndex = 0;
+      this._updateDisplay();
     }
   }
 
@@ -1012,7 +1015,37 @@ class RecentlyAddedMediaCard extends HTMLElement {
   // ── Display update ────────────────────────────────────────────────────────────
 
   _updateDisplay() {
-    if (!this._items.length) return;
+    if (!this._items.length) {
+      const cfg = this._config || {};
+      const theme = this._getTheme();
+      const primaryRgb = this._hexToRgb(theme.primary);
+      const root = this.shadowRoot;
+      const bgEl = root.querySelector('.bg-art');
+      if (bgEl) bgEl.style.backgroundImage = '';
+      const bgNew = root.querySelector('.bg-art-next');
+      if (bgNew) { bgNew.classList.remove('active'); bgNew.style.backgroundImage = ''; }
+      const posterEl = root.querySelector('.poster');
+      if (posterEl) { posterEl.src = ''; posterEl.style.opacity = '0.3'; }
+      const titleEl = root.querySelector('.item-title');
+      if (titleEl) titleEl.textContent = '';
+      const subtitleEl = root.querySelector('.item-subtitle');
+      if (subtitleEl) subtitleEl.textContent = `No recently added items available from ${cfg.server_type || 'plex'}. Configure your server URL and token, or check the connection.`;
+      const typeEl = root.querySelector('.item-type');
+      if (typeEl) { typeEl.textContent = 'No items'; typeEl.className = 'item-type movie'; }
+      const ratingEl = root.querySelector('.item-rating');
+      if (ratingEl) ratingEl.style.display = 'none';
+      const summaryEl = root.querySelector('.item-summary');
+      if (summaryEl) summaryEl.textContent = '';
+      const dotsEl = root.querySelector('.dots');
+      if (dotsEl) dotsEl.innerHTML = '';
+      const counterEl = root.querySelector('.counter');
+      if (counterEl) counterEl.textContent = '';
+      const timeEl = root.querySelector('.time-ago');
+      if (timeEl) timeEl.textContent = '';
+      const trailerBtn = root.querySelector('.trailer-btn');
+      if (trailerBtn) { trailerBtn.classList.remove('visible'); trailerBtn.onclick = null; }
+      return;
+    }
     const item = this._items[this._currentIndex];
     const root = this.shadowRoot;
 


### PR DESCRIPTION
### Root cause

`_updateDisplay()` had an early `return` when `_items.length` was zero. This code path was hit in two legitimate user-facing situations:

1. **Card added from visual editor without completing credentials** — after the skeleton loaded, `_fetchData()` resolved to an empty/failed state: the card showed only a Loading title and an otherwise blank card, described as "Card does not display at all".
2. **Connection error** — `_fetchData()` catch block showed the `.error-msg` div when it existed, but subsequent interactions could reset the skeleton, leaving a blank card with no visible content.

### Fix

**`_fetchData()` catch block** — clears `_items`, resets `_currentIndex`, and always calls `_updateDisplay()` so the card state is fully refreshed after an error.

**`_updateDisplay()`** — replaces the silent `return` on the empty-items path with an empty-state routine: clears background art and poster, sets title/subtitle and type label to descriptive messages users can read.

### This addresses

**recently-added-media-card#3** — card appears empty with no console errors after adding it to the dashboard