### PR TITLE
fix(kodi): improve connection error diagnostics

### DIFF
--- a/dist/recently-added-media-card.js
+++ b/dist/recently-added-media-card.js
@@ -1,5 +1,5 @@
 /**
- * Recently Added Media Card v2.0.0
+ * Recently Added Media Card v2.0.1
  * A unified Home Assistant Lovelace card combining Plex, Kodi, Jellyfin, and Emby
  * recently-added views into one card with a server type selector.
  *
@@ -523,17 +523,44 @@ class RecentlyAddedMediaCard extends HTMLElement {
   }
 
   async _kodiRPC(method, params = {}) {
-    const url = `${(this._config.kodi_url || '').replace(/\/$/, '')}/jsonrpc`;
+    const baseUrl = (this._config.kodi_url || '').trim();
+    if (!baseUrl) {
+      throw new Error('Kodi URL is not configured. Set kodi_url in the card config.');
+    }
+    // Validate the URL has a protocol — fetch() requires an absolute URL
+    if (!/^https?:\/\//i.test(baseUrl)) {
+      throw new Error(
+        `Kodi URL must start with http:// or https://. Got: "${baseUrl}". ` +
+        'If your Kodi is on the same machine as Home Assistant, try http://IP_ADDRESS:8080.'
+      );
+    }
+    const url = `${baseUrl.replace(/\/$/, '')}/jsonrpc`;
     const body = JSON.stringify({ jsonrpc: '2.0', method, params, id: 1 });
     let resp;
     try {
       resp = await fetch(url, { method: 'POST', headers: this._kodiHeaders(), body });
     } catch (err) {
-      const detail = err && err.message ? err.message : String(err);
-      throw new Error(`Kodi request failed before an HTTP response: ${detail}. Check that this browser can reach the Kodi URL, and that CORS or mixed-content blocking is not stopping the request.`);
+      const detail = (err && err.message ? err.message : String(err)).toLowerCase();
+      // Detect common browser-level failures and give targeted guidance
+      if (detail.includes('failed to fetch') || detail.includes('load failed') || detail.includes('networkerror')) {
+        throw new Error(
+          'Cannot reach Kodi. This is usually a browser-level block: ' +
+          'CORS (Kodi does not allow cross-origin requests by default) or ' +
+          'mixed-content (Home Assistant runs on HTTPS but Kodi uses HTTP). ' +
+          'Try opening the Kodi URL in a browser tab first. If that works, you may need to ' +
+          'enable CORS on Kodi or use an HTTPS proxy. See browser console (F12) for the exact error.'
+        );
+      }
+      throw new Error(`Kodi connection error: ${detail}`);
     }
-    if (resp.status === 401) throw new Error('Kodi authentication failed (HTTP 401). Check the username/password, including any special characters.');
-    if (!resp.ok) throw new Error(`Kodi HTTP ${resp.status}`);
+    if (resp.status === 401) {
+      throw new Error(
+        'Kodi authentication failed (HTTP 401). Check the username and password. ' +
+        'If your password contains special characters such as @ # : / ? &, ' +
+        'make sure they are entered correctly in the card config.'
+      );
+    }
+    if (!resp.ok) throw new Error(`Kodi HTTP error ${resp.status}`);
     const data = await resp.json();
     if (data.error) throw new Error(`Kodi RPC error: ${data.error.message}`);
     return data.result;


### PR DESCRIPTION
## What this fixes

Improves the Kodi connection error handling in the Recently Added Media Card to give users actionable diagnostic messages instead of raw browser errors like "Load failed".

Addresses issue #7.

## Changes

1. **URL validation** — detects missing protocol (e.g. `192.168.1.100:8080` instead of `http://192.168.1.100:8080`) and gives a clear error before the fetch even fires.

2. **CORS/mixed-content detection** — the browser's native "Load failed" / "Failed to fetch" / "NetworkError" messages are now caught and replaced with a targeted message explaining the likely causes (CORS blocking, mixed-content between HTTPS HA and HTTP Kodi) and actionable next steps (check browser console, try the URL in a browser tab, enable CORS on Kodi, use HTTPS proxy).

3. **401 error wording** — now explicitly mentions special characters in passwords (`@ # : / ? &`) so users with complex passwords can self-diagnose.

4. **Bumps version to v2.0.1.**

## How to test
1. Configure a Kodi server in the card
2. If Kodi is unreachable (CORS blocked, wrong URL, etc), you should now see a descriptive error instead of the raw "Load failed" message
3. Try with a missing protocol (e.g. `192.168.1.100:8080`) — should get a clear validation error