### PR TITLE
fix: checkbox editor values + allow disabling auto-advance (#12, #13)

### DIFF
--- a/dist/recently-added-media-card.js
+++ b/dist/recently-added-media-card.js
@@ -204,7 +204,8 @@ class RecentlyAddedMediaCardEditor extends HTMLElement {
         <div class="grid-2">
           <div class="field-row">
             <label>Cycle Interval (seconds)</label>
-            <input type="number" id="cycle_interval" min="3" max="60" value="${escapeAttr(cfg.cycle_interval !== undefined ? cfg.cycle_interval : 8)}">
+            <input type="number" id="cycle_interval" min="0" max="60" value="${escapeAttr(cfg.cycle_interval !== undefined ? cfg.cycle_interval : 8)}">
+            <span class="helper">Set to 0 to disable auto-advance.</span>
           </div>
           <div class="field-row">
             <label>Card Title</label>
@@ -294,7 +295,6 @@ class RecentlyAddedMediaCardEditor extends HTMLElement {
       'emby_url', 'emby_api_key', 'emby_user_id',
       'movies_count', 'shows_count', 'cycle_interval', 'title',
       'theme', 'card_height', 'tmdb_api_key', 'trailer_mode',
-      'mobile_mode', 'show_shimmer',
     ];
 
     fields.forEach(id => {
@@ -313,6 +313,18 @@ class RecentlyAddedMediaCardEditor extends HTMLElement {
         this._fireChange('fill_height', fillEl.checked);
       });
     }
+
+    // Checkbox toggles must send their checked state, not el.value (which
+    // is always "on" for a checkbox). The generic handler above can't be
+    // used for these, or saving silently breaks.
+    ['mobile_mode', 'show_shimmer'].forEach(id => {
+      const el = root.getElementById(id);
+      if (el) {
+        el.addEventListener('change', () => {
+          this._fireChange(id, el.checked);
+        });
+      }
+    });
   }
 
   _fireChange(key, value) {
@@ -373,7 +385,7 @@ class RecentlyAddedMediaCard extends HTMLElement {
       server_type: serverType,
       movies_count: config.movies_count || 5,
       shows_count: config.shows_count || 5,
-      cycle_interval: config.cycle_interval || 8,
+      cycle_interval: config.cycle_interval !== undefined ? config.cycle_interval : 8,
       title: config.title !== undefined ? config.title : 'Recently Added',
       theme: config.theme || 'auto',
       show_shimmer: config.show_shimmer || false,
@@ -1057,13 +1069,17 @@ class RecentlyAddedMediaCard extends HTMLElement {
 
   _startCycle() {
     if (this._cycleTimer) clearInterval(this._cycleTimer);
+    this._cycleTimer = null;
+    // cycle_interval 0 (or less) disables auto-advance entirely.
+    const interval = Number(this._config.cycle_interval);
+    if (!Number.isFinite(interval) || interval <= 0) return;
     if (this._items.length <= 1) return;
 
     this._cycleTimer = setInterval(() => {
       if (this._trailerActive) return; // Pause cycling while trailer is playing
       this._currentIndex = (this._currentIndex + 1) % this._items.length;
       this._updateDisplay();
-    }, this._config.cycle_interval * 1000);
+    }, interval * 1000);
   }
 
   _resetCycleTimer() {


### PR DESCRIPTION
## What

Fixes #13 (mobile scaling / poster shimmer toggles not saving in the UI) and #12 (cannot disable card auto-advance).

## Changes

### #13 Checkbox toggles not saving
The editor's generic change handler read `el.value` for every field. For checkboxes `el.value` is always the string `'on'`, so toggling `mobile_mode` or `show_shimmer` never produced a real config change and the values reverted when any other option was saved. Both toggles now have dedicated handlers that fire the `checked` boolean, matching how `fill_height` was already handled.

### #12 Disable auto-advance
- `cycle_interval` now accepts 0 (editor min lowered from 3 to 0, helper text added).
- `_startCycle()` returns early when the interval is 0 or less, so the timer never starts.
- `setConfig()` no longer coerces 0 back to the default 8 via `||`.

Note: this repo ships the built `dist/recently-added-media-card.js` directly (no src/), so edits are in dist. `node --check` passes.
