### PR TITLE
feat: add newest-first item ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A cinematic Home Assistant card that displays recently added movies and TV shows
 - **Swipe navigation** — swipe left/right on touch devices or click-and-drag on desktop to move through the carousel
 - **Cinematic design** — blurred background art, poster on left, info on right, smooth crossfade transitions
 - **Auto-cycling carousel** — rotates through recently added items with colour-coded dots (movie/TV)
+- **Configurable item order** — alternate movies and TV shows, or sort all items by newest added
 - **Synopsis and metadata** — title, year, genres, content rating, star rating, time since added, and full synopsis
 - **Visual editor** — configure everything from the HA UI with dynamic fields per server type
 - **Fill height / fixed height** — adapts to any HA layout mode
@@ -86,6 +87,7 @@ plex_url: http://YOUR_PLEX_IP:32400
 plex_token: YOUR_PLEX_TOKEN
 movies_count: 5
 shows_count: 5
+sort_order: recent
 cycle_interval: 8
 title: Recently Added
 tmdb_api_key: YOUR_TMDB_READ_ACCESS_TOKEN  # Optional: enables trailers
@@ -156,6 +158,7 @@ tmdb_api_key: YOUR_TMDB_READ_ACCESS_TOKEN
 | `emby_user_id` | string | — | Emby user ID |
 | `movies_count` | number | `5` | Number of recently added movies to display |
 | `shows_count` | number | `5` | Number of recently added TV shows to display |
+| `sort_order` | string | `interleaved` | `interleaved` alternates movies and TV shows; `recent` sorts all items together by newest added |
 || `cycle_interval` | number | `8` | Seconds between cycling to the next item |
 || `title` | string | `"Recently Added"` | Header text (set to empty string to hide) |
 || `theme` | string | `"auto"` | Colour theme: `auto`, `plex`, `kodi`, `jellyfin`, `emby`, `dark`, `midnight`, `sunset`, `forest` |
@@ -225,7 +228,7 @@ The card connects directly to your media server's API from the browser and fetch
 - **Jellyfin**: Calls the `/Users/{userId}/Items/Latest` endpoint filtered by movie and series types
 - **Emby**: Same approach as Jellyfin with Emby's API endpoints
 
-Items are interleaved (movie, show, movie, show...) and displayed in a cycling carousel with smooth crossfade transitions.
+Items are interleaved by default (movie, show, movie, show...). Set `sort_order: recent` to combine movies and TV shows into strict newest-added order. Items are displayed in a cycling carousel with smooth crossfade transitions.
 
 ### Important Notes
 

--- a/dist/recently-added-media-card.js
+++ b/dist/recently-added-media-card.js
@@ -91,6 +91,7 @@ class RecentlyAddedMediaCardEditor extends HTMLElement {
     const cfg = this._config;
     const serverType = cfg.server_type || 'plex';
     const theme = cfg.theme || 'auto';
+    const sortOrder = cfg.sort_order || 'interleaved';
 
     this.shadowRoot.innerHTML = `
       <style>
@@ -201,6 +202,14 @@ class RecentlyAddedMediaCardEditor extends HTMLElement {
             <input type="number" id="shows_count" min="1" max="20" value="${escapeAttr(cfg.shows_count !== undefined ? cfg.shows_count : 5)}">
           </div>
         </div>
+        <div class="field-row">
+          <label>Item Order</label>
+          <select id="sort_order">
+            <option value="interleaved" ${sortOrder === 'interleaved' ? 'selected' : ''}>Alternate movies and TV shows</option>
+            <option value="recent" ${sortOrder === 'recent' ? 'selected' : ''}>Newest added first</option>
+          </select>
+          <span class="helper">Newest first sorts movies and TV shows together by their added date.</span>
+        </div>
         <div class="grid-2">
           <div class="field-row">
             <label>Cycle Interval (seconds)</label>
@@ -293,7 +302,7 @@ class RecentlyAddedMediaCardEditor extends HTMLElement {
       'kodi_url', 'kodi_username', 'kodi_password',
       'jellyfin_url', 'jellyfin_api_key', 'jellyfin_user_id',
       'emby_url', 'emby_api_key', 'emby_user_id',
-      'movies_count', 'shows_count', 'cycle_interval', 'title',
+      'movies_count', 'shows_count', 'sort_order', 'cycle_interval', 'title',
       'theme', 'card_height', 'tmdb_api_key', 'trailer_mode',
     ];
 
@@ -385,6 +394,7 @@ class RecentlyAddedMediaCard extends HTMLElement {
       server_type: serverType,
       movies_count: config.movies_count || 5,
       shows_count: config.shows_count || 5,
+      sort_order: config.sort_order || 'interleaved',
       cycle_interval: config.cycle_interval !== undefined ? config.cycle_interval : 8,
       title: config.title !== undefined ? config.title : 'Recently Added',
       theme: config.theme || 'auto',
@@ -435,6 +445,7 @@ class RecentlyAddedMediaCard extends HTMLElement {
       plex_token: 'YOUR_PLEX_TOKEN',
       movies_count: 5,
       shows_count: 5,
+      sort_order: 'interleaved',
       cycle_interval: 8,
       title: 'Recently Added',
       theme: 'auto',
@@ -1056,6 +1067,12 @@ class RecentlyAddedMediaCard extends HTMLElement {
   // ── Interleave utility ────────────────────────────────────────────────────────
 
   _interleave(movies, tvShows) {
+    if (this._config.sort_order === 'recent') {
+      return [...movies, ...tvShows].sort(
+        (a, b) => (Number(b.addedAt) || 0) - (Number(a.addedAt) || 0)
+      );
+    }
+
     const result = [];
     const maxLen = Math.max(movies.length, tvShows.length);
     for (let i = 0; i < maxLen; i++) {

--- a/test/sort-order.test.js
+++ b/test/sort-order.test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const cardSource = fs.readFileSync(
+  path.join(__dirname, '..', 'dist', 'recently-added-media-card.js'),
+  'utf8'
+);
+const context = {
+  HTMLElement: class HTMLElement {},
+  customElements: { define() {} },
+  console,
+  window: { customCards: [] },
+};
+vm.createContext(context);
+vm.runInContext(
+  `${cardSource}\nglobalThis.RecentlyAddedMediaCardForTest = RecentlyAddedMediaCard;`,
+  context
+);
+
+function cardWithOrder(sortOrder) {
+  const card = Object.create(context.RecentlyAddedMediaCardForTest.prototype);
+  card._config = { sort_order: sortOrder };
+  return card;
+}
+
+const movies = [
+  { title: 'Older movie', addedAt: 100 },
+  { title: 'Newest movie', addedAt: 400 },
+];
+const tvShows = [
+  { title: 'Newest show', addedAt: 500 },
+  { title: 'Older show', addedAt: 200 },
+];
+
+test('recent order combines both media types by added date', () => {
+  const result = cardWithOrder('recent')._interleave(movies, tvShows);
+
+  assert.deepEqual(
+    Array.from(result, (item) => item.title),
+    ['Newest show', 'Newest movie', 'Older show', 'Older movie']
+  );
+});
+
+test('default order remains interleaved for backwards compatibility', () => {
+  const result = cardWithOrder('interleaved')._interleave(movies, tvShows);
+
+  assert.deepEqual(
+    Array.from(result, (item) => item.title),
+    ['Older movie', 'Newest show', 'Newest movie', 'Older show']
+  );
+});
+
+test('items without an added date sort after dated items', () => {
+  const result = cardWithOrder('recent')._interleave(
+    [{ title: 'Undated movie' }],
+    [{ title: 'Dated show', addedAt: 10 }]
+  );
+
+  assert.deepEqual(
+    Array.from(result, (item) => item.title),
+    ['Dated show', 'Undated movie']
+  );
+});


### PR DESCRIPTION
## Summary

Adds an optional item-order setting for #11. The existing movie/TV alternation remains the default for backwards compatibility, while `sort_order: recent` combines both media types and sorts them by added date.

## Changes

- add an **Item Order** selector to the visual editor
- support `sort_order: interleaved` and `sort_order: recent`
- document the YAML option and behaviour
- add regression coverage for chronological, interleaved, and missing-date handling

## Verification

- `node --check dist/recently-added-media-card.js`
- `node --check test/sort-order.test.js`
- `node --test test/sort-order.test.js` (3 passed)