### PR TITLE
Add sort_order option: merge movies and shows by date added

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ tmdb_api_key: YOUR_TMDB_READ_ACCESS_TOKEN
 | `emby_user_id` | string | — | Emby user ID |
 | `movies_count` | number | `5` | Number of recently added movies to display |
 | `shows_count` | number | `5` | Number of recently added TV shows to display |
+| `sort_order` | string | `"interleave"` | How movies and shows are combined: `interleave` (alternate movies/shows) or `added_at` (merge both lists and sort strictly by most recently added) |
 || `cycle_interval` | number | `8` | Seconds between cycling to the next item |
 || `title` | string | `"Recently Added"` | Header text (set to empty string to hide) |
 || `theme` | string | `"auto"` | Colour theme: `auto`, `plex`, `kodi`, `jellyfin`, `emby`, `dark`, `midnight`, `sunset`, `forest` |

--- a/dist/recently-added-media-card.js
+++ b/dist/recently-added-media-card.js
@@ -208,6 +208,14 @@ class RecentlyAddedMediaCardEditor extends HTMLElement {
             <span class="helper">Set to 0 to disable auto-advance.</span>
           </div>
           <div class="field-row">
+            <label>Sort Order</label>
+            <select id="sort_order">
+              <option value="interleave" ${(cfg.sort_order || 'interleave') === 'interleave' ? 'selected' : ''}>Interleave movies and shows</option>
+              <option value="added_at" ${cfg.sort_order === 'added_at' ? 'selected' : ''}>Strictly by date added</option>
+            </select>
+            <span class="helper">Default interleaves each list; "date added" merges movies and shows into a single most-recently-added order.</span>
+          </div>
+          <div class="field-row">
             <label>Card Title</label>
             <input type="text" id="title" value="${escapeAttr(cfg.title !== undefined ? cfg.title : 'Recently Added')}">
           </div>
@@ -294,7 +302,7 @@ class RecentlyAddedMediaCardEditor extends HTMLElement {
       'jellyfin_url', 'jellyfin_api_key', 'jellyfin_user_id',
       'emby_url', 'emby_api_key', 'emby_user_id',
       'movies_count', 'shows_count', 'cycle_interval', 'title',
-      'theme', 'card_height', 'tmdb_api_key', 'trailer_mode',
+      'sort_order', 'theme', 'card_height', 'tmdb_api_key', 'trailer_mode',
     ];
 
     fields.forEach(id => {
@@ -386,6 +394,7 @@ class RecentlyAddedMediaCard extends HTMLElement {
       movies_count: config.movies_count || 5,
       shows_count: config.shows_count || 5,
       cycle_interval: config.cycle_interval !== undefined ? config.cycle_interval : 8,
+      sort_order: config.sort_order || 'interleave',
       title: config.title !== undefined ? config.title : 'Recently Added',
       theme: config.theme || 'auto',
       show_shimmer: config.show_shimmer || false,
@@ -436,6 +445,7 @@ class RecentlyAddedMediaCard extends HTMLElement {
       movies_count: 5,
       shows_count: 5,
       cycle_interval: 8,
+      sort_order: 'interleave',
       title: 'Recently Added',
       theme: 'auto',
       fill_height: true,
@@ -1053,9 +1063,15 @@ class RecentlyAddedMediaCard extends HTMLElement {
     return this._interleave(movieItems, tvDisplayItems);
   }
 
-  // ── Interleave utility ────────────────────────────────────────────────────────
+  // ── Combine utility ──────────────────────────────────────────────────────────
 
   _interleave(movies, tvShows) {
+    const sortOrder = this._config.sort_order || 'interleave';
+    if (sortOrder === 'added_at') {
+      const combined = [...movies, ...tvShows];
+      combined.sort((a, b) => (b.addedAt || 0) - (a.addedAt || 0));
+      return combined;
+    }
     const result = [];
     const maxLen = Math.max(movies.length, tvShows.length);
     for (let i = 0; i < maxLen; i++) {


### PR DESCRIPTION
## What

Adds a `sort_order` config option with two values:

- `interleave` (default): current behaviour - movies and shows alternate
- `added_at`: both lists are merged and sorted strictly by most recently added, so the newest item always appears first regardless of media type

## Changes

- `_interleave` (the combine utility) branches on `this._config.sort_order` and sorts the merged list by `addedAt` descending when set to `added_at`
- `setConfig` and `getStubConfig` default `sort_order` to `interleave` (backwards compatible)
- Visual editor gains a Sort Order select in the Content section
- README options table documents the new option

## Why

Reported in #11: users expect the card to honour "most recently added" globally, not per media type. Default is unchanged so existing dashboards behave identically.

## Test

Syntax validated with `node --check`. Sort logic smoke-tested: `added_at` returns items in strict addedAt-descending order across movies and shows.
